### PR TITLE
fix: replace with androidx test runner

### DIFF
--- a/fragmentviewbindingdelegate-kt/build.gradle.kts
+++ b/fragmentviewbindingdelegate-kt/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         targetSdkVersion(28)
         versionCode = 1
         versionName = "1.0.0"
-        testInstrumentationRunner = "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {


### PR DESCRIPTION
### Changed:
Use `androidx.test.runner.AndroidJUnitRunner` instead to be consistent with the project.