### PR TITLE
Update getValue to use thisRef instead of fragment

### DIFF
--- a/fragmentviewbindingdelegate-kt/src/main/java/com/zhuinden/fragmentviewbindingdelegatekt/FragmentViewBindingDelegate.kt
+++ b/fragmentviewbindingdelegate-kt/src/main/java/com/zhuinden/fragmentviewbindingdelegatekt/FragmentViewBindingDelegate.kt
@@ -60,7 +60,7 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
             return binding
         }
 
-        val lifecycle = fragment.viewLifecycleOwner.lifecycle
+        val lifecycle = thisRef.viewLifecycleOwner.lifecycle
         if (!lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
             throw IllegalStateException("Should not attempt to get bindings when Fragment views are destroyed.")
         }


### PR DESCRIPTION
When using FragmentScenario, the following exception occurs:
```
java.lang.IllegalStateException: Can't access the Fragment View's LifecycleOwner when getView() is null i.e., before onCreateView() or after onDestroyView()
	at androidx.fragment.app.Fragment.getViewLifecycleOwner(Fragment.java:361)
	at com.zhuinden.fragmentviewbindingdelegatekt.FragmentViewBindingDelegate.getValue(FragmentViewBindingDelegate.kt:63)
```

Not sure why this makes a difference since `fragment` and `thisRef` should be the same instance, but it seems to prevent the crash.