### PR TITLE
Switch to FragmentManager.FragmentLifecycleCallbacks

### DIFF
--- a/fragmentviewbindingdelegate-kt/build.gradle.kts
+++ b/fragmentviewbindingdelegate-kt/build.gradle.kts
@@ -41,10 +41,7 @@ android {
 }
 
 dependencies {
-    //implementation(mapOf("dir" to "libs", "include" to listOf("*.jar")))
-    api("androidx.lifecycle:lifecycle-common-java8:2.2.0")
     implementation("androidx.fragment:fragment-ktx:1.2.5")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.2.0")
 
     testImplementation("junit:junit:4.13.1")
     testImplementation("org.assertj:assertj-core:3.16.1")


### PR DESCRIPTION
Making the switch to Fragment LCCs should fix #12, since the view lifecycle destroy event gets called _before_ `onDestroyView`, but only `onFragmentViewDestroyed` gets called _after_. (As a side effect we can also drop the livedata dependency)

(Sidenote: I have not tested this in an actual project yet, will try to do so next week)

Curious what you think