### PR TITLE
Add ViewBinding::inflate support with `viewInflateBinding`

### DIFF
--- a/fragmentviewbindingdelegate-kt/src/main/java/com/zhuinden/fragmentviewbindingdelegatekt/FragmentViewBindingDelegate.kt
+++ b/fragmentviewbindingdelegate-kt/src/main/java/com/zhuinden/fragmentviewbindingdelegatekt/FragmentViewBindingDelegate.kt
@@ -15,6 +15,7 @@
  */
 package com.zhuinden.fragmentviewbindingdelegatekt
 
+import android.view.LayoutInflater
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -27,7 +28,7 @@ import kotlin.reflect.KProperty
 
 class FragmentViewBindingDelegate<T : ViewBinding>(
     val fragment: Fragment,
-    val viewBindingFactory: (View) -> T
+    val viewBindingFactory: (Fragment) -> T
 ) : ReadOnlyProperty<Fragment, T> {
     private var binding: T? = null
 
@@ -65,9 +66,18 @@ class FragmentViewBindingDelegate<T : ViewBinding>(
             throw IllegalStateException("Should not attempt to get bindings when Fragment views are destroyed.")
         }
 
-        return viewBindingFactory(thisRef.requireView()).also { this.binding = it }
+        return viewBindingFactory(thisRef).also { this.binding = it }
     }
 }
 
-fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
-    FragmentViewBindingDelegate(this, viewBindingFactory)
+@Suppress("unused")
+inline fun <T : ViewBinding> Fragment.viewBinding(
+    crossinline viewBindingFactory: (View) -> T
+): FragmentViewBindingDelegate<T> =
+    FragmentViewBindingDelegate(this) { f -> viewBindingFactory(f.requireView()) }
+
+@Suppress("unused")
+inline fun <T : ViewBinding> Fragment.viewInflateBinding(
+    crossinline bindingInflater: (LayoutInflater) -> T
+): FragmentViewBindingDelegate<T> =
+    FragmentViewBindingDelegate(this) { f -> bindingInflater(f.layoutInflater) }


### PR DESCRIPTION
We can switch the factory to work with `fragment` to add support for ViewBinding::inflate as an alternative (which should resolve #8). I also switched to inline functions to avoid multiple lambdas/callbacks

Technically this would be a breaking change, since the constructor is public and the signature changes, even though nobody should be affected 🤔 