### PR TITLE
Fix changelog message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 -FragmentViewBindingDelegate-KT 1.0.2 (2022-10-29)
 --------------------------------
 
-- CHANGE: use `view != null` instead of `lifecycle.isAtLeast(INITIALIZED)` to allow people to create and destroy a view in onDestroyView. (thanks @kendrickkwok and @dptsolutions)
+- CHANGE: use `view != null` instead of `lifecycle.isAtLeast(INITIALIZED)` to allow people to create and destroy a binding in onDestroyView. (thanks @kendrickkwok and @dptsolutions)
 
 - CHANGE: recreate binding if the view doesn't match the one in the fragment (should fix the binding in retained fragments)
 


### PR DESCRIPTION
Technically, we now allow creation and destruction of the binding in `onDestroyView()`.